### PR TITLE
added DbContext. Having trouble with dictionary.

### DIFF
--- a/RecipeAPI/Models/Recipe.cs
+++ b/RecipeAPI/Models/Recipe.cs
@@ -5,7 +5,7 @@
         public int Id { get; set; }
         public Dictionary<int,string>? Directions { get; set; }
         public List<string>? Ingredients { get; set; }
-        public DateOnly DateAdded { get; set; }
+        public DateTime DateAdded { get; set; }
         public string? Source { get; set; }
     }
 }

--- a/RecipeAPI/Models/RecipeContext.cs
+++ b/RecipeAPI/Models/RecipeContext.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System.Diagnostics.CodeAnalysis;
+
+namespace RecipeAPI.Models
+{
+    public class RecipeContext : DbContext
+    {
+        public RecipeContext(DbContextOptions<RecipeContext> options)
+            : base(options)
+        {
+        }
+        public DbSet<Recipe> Recipes { get; set; } = null!;
+    }
+}

--- a/RecipeAPI/Program.cs
+++ b/RecipeAPI/Program.cs
@@ -1,9 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using RecipeAPI.Models;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
 builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddDbContext<RecipeContext>(opt =>
+    opt.UseInMemoryDatabase("RecipeAPI"));
+
 builder.Services.AddEndpointsApiExplorer();
 
 var app = builder.Build();

--- a/RecipeAPI/RecipeAPI.csproj
+++ b/RecipeAPI/RecipeAPI.csproj
@@ -7,11 +7,20 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.23" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.23">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.16" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Controllers\" />
   </ItemGroup>
+
+  <ProjectExtensions><VisualStudio><UserProperties appsettings_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
 
 </Project>

--- a/RecipeAPI/appsettings.json
+++ b/RecipeAPI/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "RecipeContext": "Server=(localdb)\\mssqllocaldb;Database=RecipeAPI.Data;Trusted_Connection=True;MultipleActiveResultSets=true"
+  }
 }


### PR DESCRIPTION
I updated the Recipe class to change the DateAdded to be DateTime. I added the database context and then tried to add a new scaffolded item so that I could add a controller to the project. When I do that I get the following error: "unable to determine the relationship represented by navigation".

It's related to the Dictionary. When I did some searching it looks like this often happens when there is a many to many relationship, however the key value pairs for each recipe should be unique as the directions should not be the same for any 2 recipes. And all the examples I found had to do with adding multiple tables. I only have 1 table. I did also search how to configure navigation properties because I assume the solution is to do it myself but I did not find anything particularly helpful.

Another option would be to just add the [NotMapped] attribute to Directions but if we were to expand on this I would think that I would want this mapped correct? So I'm checking in the small changes I made and also asking if you can point me in the right direction. 